### PR TITLE
Release action.

### DIFF
--- a/.github/workflows/publish-test.yaml
+++ b/.github/workflows/publish-test.yaml
@@ -1,0 +1,39 @@
+name: Publish Python Distro to Test PyPi
+
+on: push
+
+jobs:
+  build-and-publish:
+
+    name: Build and Publish
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish to Test PY
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish Python Distro to Test PyPi
+name: Publish Python Package to PyPi
 
 on: push
 
@@ -32,7 +32,7 @@ jobs:
         --outdir dist/
         .
 
-    - name: Publish to Test PY
+    - name: Publish to pypi
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ jobs:
   build-and-publish:
 
     name: Build and Publish
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-18.04
 
     steps:
@@ -35,5 +35,4 @@ jobs:
     - name: Publish to Test PY
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,12 +1,12 @@
 name: Publish Python Package to PyPi
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
-
     name: Build and Publish
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-18.04
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,7 @@
-import os
-import re
-
 from setuptools import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
-
-
-def get_version():
-    commit_tag = os.getenv("CI_COMMIT_TAG", "latest")
-    stage = os.getenv("CI_JOB_STAGE", "local")
-
-    if stage == "publish":
-        if commit_tag == "latest":
-            raise ValueError("Did not get a commit tag during publishing.")
-
-        if not re.match(r"^release-\d+\.\d+\.\d+$", commit_tag):
-            raise ValueError("Wrong tag format.")
-
-        commit_tag = commit_tag.split("-")[1]
-
-    return commit_tag
 
 
 packages = []
@@ -29,12 +10,12 @@ with open("requirements.txt") as requirements:
 
 setup(
     name="kubeobject",
-    version=get_version(),
+    version="0.2.0",
 
     author="Rodrigo Valin",
     author_email="rodrigo.valin@mongodb.com",
     description="Easily Manage Kubernetes Objects.",
-    url='https://github.com/10gen/kubeobject',
+    url='https://github.com/mongodb/kubeobject',
 
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds a release action.

This is a simple implementation to be able to push to pypi.org. We can do something better in the future, but for now I want to be able to release 0.2.0 and to start using that version, from *this* repo, in the Enterprise operator.